### PR TITLE
[g5k] Expose the queue name

### DIFF
--- a/enoslib/infra/enos_g5k/api.py
+++ b/enoslib/infra/enos_g5k/api.py
@@ -86,11 +86,16 @@ class Resources:
         job_name = kwargs.get("job_name", JOB_NAME)
         walltime = kwargs.get("walltime", WALLTIME)
         reservation_date = kwargs.get("reservation", False)
+        # NOTE(msimonin): some time ago asimonet proposes to auto-detect
+        # the queues and it was quiet convenient
+        # see https://github.com/BeyondTheClouds/enos/pull/62
+        queue = kwargs.get("queue", None)
         gridjob = utils.get_or_create_job(
             self.c_resources,
             job_name,
             walltime,
-            reservation_date)
+            reservation_date,
+            queue)
         utils.concretize_resources(self.c_resources, gridjob)
 
     def deploy(self, **kwargs):

--- a/enoslib/infra/enos_g5k/utils.py
+++ b/enoslib/infra/enos_g5k/utils.py
@@ -38,11 +38,11 @@ def to_vlan_type(vlan_id):
     return KAVLAN_GLOBAL
 
 
-def get_or_create_job(resources, job_name, walltime, reservation_date):
+def get_or_create_job(resources, job_name, walltime, reservation_date, queue):
     gridjob, _ = ex5.planning.get_job_by_name(job_name)
     if gridjob is None:
         gridjob = make_reservation(resources, job_name, walltime,
-            reservation_date)
+            reservation_date, queue)
     logging.info("Waiting for oargridjob %s to start" % gridjob)
     ex5.wait_oargrid_job_start(gridjob)
     return gridjob
@@ -184,7 +184,7 @@ def concretize_networks(resources, vlans):
 
 
 def make_reservation(resources, job_name, walltime,
-    reservation_date):
+    reservation_date, queue):
     machines = resources["machines"]
     networks = resources["networks"]
 
@@ -214,7 +214,8 @@ def make_reservation(resources, job_name, walltime,
         jobs_specs,
         walltime=walltime.encode('ascii', 'ignore'),
         reservation_date=reservation_date,
-        job_type='deploy')
+        job_type='deploy',
+        queue=queue)
 
     if gridjob is None:
         raise Exception('No oar job was created')


### PR DESCRIPTION
queue name can be specified in the job description of the g5k provider.
```
---
g5k:
  job_name: sesame
  walltime: '3:30:00'
  queue: testing
```

For now this will enforce the queue for all the resources reserved:
you can't mix resources from different queues.