### PR TITLE
Adding network constraints

### DIFF
--- a/enoslib/ansible/roles/utils/templates/ips.txt.j2
+++ b/enoslib/ansible/roles/utils/templates/ips.txt.j2
@@ -4,7 +4,7 @@
   all_ipv4_addresses:
 {{hostvars[host]['ansible_all_ipv4_addresses'] | to_nice_yaml(2) | indent(width=4, indentfirst=true)}}
   devices:
-{% for enos_device in enos_devices %}
+{% for enos_device in hostvars[host]['enos_devices'] %}
   -
 {{ hostvars[host]['ansible_' + enos_device] | to_nice_yaml(2) | indent(width=4, indentfirst=true)}}
 {% endfor %}

--- a/enoslib/api.py
+++ b/enoslib/api.py
@@ -733,6 +733,8 @@ def _merge_constraints(constraints, overrides):
                 constraints[i].update(o)
                 break
             i = i + 1
+        else:
+            constraints.append(o)
 
 
 def _build_grp_constraints(roles, network_constraints):

--- a/enoslib/api.py
+++ b/enoslib/api.py
@@ -768,6 +768,12 @@ def _build_ip_constraints(roles, ips, constraints):
             # Get all the active devices for this source
             active_devices = filter(lambda x: x["active"],
                                     local_ips[s.alias]['devices'])
+            # Get only the devices specified in the network constraint
+            if 'network' in constraint:
+                active_devices = filter(
+                    lambda x:
+                    x['device'] == s.extra[constraint['network']],
+                    active_devices)
             # Get only the name of the active devices
             sdevices = map(lambda x: x['device'], active_devices)
             for sdevice in sdevices:


### PR DESCRIPTION
- The first commit https://github.com/Marie-Donnie/enoslib/commit/430faaab334b4cd65547c389093004e7377a7925 adds a constraint even if the src/dst couple is not already in the constraints. It still needs to specify a delay, rate and loss, as follows:
```
{
        "src": "database",
        "dst": "database",
        "delay": "0ms",
        "rate": "10gbit",
        "loss": "0",
}
```
- The second commit https://github.com/Marie-Donnie/enoslib/commit/897f66a2d7b97efea32aa9d81fc26b877bbeb58c corrects the fact that ansible only uses enos_devices defined by the first node (I think). I used the solution that was already given by [the host template](https://github.com/BeyondTheClouds/enoslib/blob/master/enoslib/ansible/roles/utils/templates/hosts.txt.j2#L3)

- The third commit https://github.com/Marie-Donnie/enoslib/commit/a0d7f7f7e77d46bb3be2cb3a34dae93793a1f44b enables to specify a network to apply the constraint on to avoid to apply the constraint on all network used by the src or dst in the constraint.
example:
```
"constraints": [{
        "src": "database",
        "dst": "database",
        "delay": "0ms",
        "rate": "10gbit",
        "loss": "0",
        "network": "database_network",
}],
```