### PR TITLE
WiP [g5k] allow "non deploy" reservation

### DIFF
--- a/docs/tutorials/grid5000.rst
+++ b/docs/tutorials/grid5000.rst
@@ -51,3 +51,21 @@ The following ``tuto_grid5000_subnet.py`` shows how to deal with a subnet reserv
 .. literalinclude:: grid5000/tuto_grid5000_subnet.py
     :language: python
     :linenos:
+
+
+Non deploy reservation
+----------------------
+
+The following ``tuto_grid5000_non_deploy.py`` shows how to deal with a non
+deploy reservation. Root ssh access will be granted to the nodes. For this
+purpose you must have a ``~/.ssh/id_rsa.pub`` file available. All the
+connections will be done as root user allowing to mimic the behaviour of deploy
+jobs (without the kadeploy3 step). This is particularly interesting if your
+deployment does't require more than one network interface.
+
+.. literalinclude:: grid5000/tuto_grid5000_non_deploy.py
+    :language: python
+    :linenos:
+
+
+

--- a/docs/tutorials/grid5000/tuto_grid5000_non_deploy.py
+++ b/docs/tutorials/grid5000/tuto_grid5000_non_deploy.py
@@ -1,0 +1,47 @@
+from enoslib.api import generate_inventory
+from enoslib.infra.enos_g5k.provider import G5k
+
+import logging
+import os
+
+logging.basicConfig(level=logging.INFO)
+
+provider_conf = {
+    "job_type": "allow_classic_ssh",
+    "job_name": "test-non-deploy",
+    "resources": {
+        "machines": [{
+            "role": "control",
+            "cluster": "parapluie",
+            "nodes": 1,
+            "primary_network": "n1",
+            "secondary_networks": []
+        },{
+
+            "roles": ["control", "compute"],
+            "cluster": "parapluie",
+            "nodes": 1,
+            "primary_network": "n1",
+            "secondary_networks": []
+        }],
+        "networks": [{
+            "id": "n1",
+            "type": "prod",
+            "role": "my_network",
+            "site": "rennes",
+         }]
+    }
+}
+
+# path to the inventory
+inventory = os.path.join(os.getcwd(), "hosts")
+
+# claim the resources
+provider = G5k(provider_conf)
+roles, networks = provider.init()
+
+# generate an inventory compatible with ansible
+generate_inventory(roles, networks, inventory, check_networks=True)
+
+# destroy the reservation
+provider.destroy()

--- a/enoslib/infra/enos_g5k/provider.py
+++ b/enoslib/infra/enos_g5k/provider.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG = {
     'walltime': '02:00:00',
     'env_name': 'debian9-x64-nfs',
     'reservation': False,
+    'job_type': 'deploy'
 }
 
 
@@ -34,6 +35,7 @@ def _to_enos_roles(roles):
         for nic, roles in h["nics"]:
             for role in roles:
                 extra[role] = nic
+
         return Host(h["host"], user="root", extra=extra)
 
     enos_roles = {}


### PR DESCRIPTION
`job_type` can be passed in the configuration. Its value can
be any job type supported but this mainly should be `deploy`
or `allow_classic_ssh`.
The former correspond to the previous situation.
The latter is new. This will reserve production node, this
won't call kadeploy3 but instead user will be granted root
access to the nodes.  Starting from this point, user can
interact as usual with its nodes.