### PR TITLE
Add support for regions for Chameleon

### DIFF
--- a/enoslib/infra/enos_chameleonbaremetal/provider.py
+++ b/enoslib/infra/enos_chameleonbaremetal/provider.py
@@ -148,7 +148,8 @@ def check_reservation(config):
 
 
 def check_extra_ports(session, network, total):
-    nclient = neutron.Client('2', session=session)
+    nclient = neutron.Client('2', session=session,
+                             region_name=os.environ['OS_REGION_NAME'])
     ports = nclient.list_ports()['ports']
     logger.debug("Found %s ports" % ports)
     port_name = PORT_NAME
@@ -194,7 +195,7 @@ class Chameleonbaremetal(cc.Chameleonkvm):
             os_servers = openstack.check_servers(
                 env['session'],
                 {"machines": machines},
-                extra_prefix=flavor,
+                extra_prefix="{}-{}".format(conf['prefix'], flavor),
                 force_deploy=force_deploy,
                 key_name=conf.get('key_name'),
                 image_id=env['image_id'],

--- a/enoslib/infra/enos_chameleonbaremetal/provider.py
+++ b/enoslib/infra/enos_chameleonbaremetal/provider.py
@@ -52,14 +52,16 @@ def create_blazar_client(config):
     auth = kclient.authenticate()
     if auth:
         blazar_url = kclient.service_catalog.url_for(
-            service_type='reservation')
+            service_type='reservation',
+            region_name=os.environ["OS_REGION_NAME"])
     else:
         raise Exception("User *%s* is not authorized." %
                 os.environ["OS_USERNAME"])
 
     # let the version by default
     return blazar_client.Client(blazar_url=blazar_url,
-            auth_token=kclient.auth_token)
+            auth_token=kclient.auth_token,
+            region_name=os.environ["OS_REGION_NAME"])
 
 
 def get_reservation(bclient, provider_conf):

--- a/enoslib/infra/enos_chameleonbaremetal/provider.py
+++ b/enoslib/infra/enos_chameleonbaremetal/provider.py
@@ -62,9 +62,9 @@ def create_blazar_client(config):
             auth_token=kclient.auth_token)
 
 
-def get_reservation(bclient):
+def get_reservation(bclient, provide_conf):
     leases = bclient.lease.list()
-    leases = [l for l in leases if l["name"] == LEASE_NAME]
+    leases = [l for l in leases if l["name"] == provider_conf['lease_name']]
     if len(leases) >= 1:
         lease = leases[0]
         if lease_is_reusable(lease):
@@ -134,7 +134,7 @@ def wait_reservation(bclient, lease):
 
 def check_reservation(config):
     bclient = create_blazar_client(config)
-    lease = get_reservation(bclient)
+    lease = get_reservation(bclient, config)
     if lease is None:
         lease = create_reservation(bclient, config)
     wait_reservation(bclient, lease)
@@ -219,7 +219,7 @@ class Chameleonbaremetal(cc.Chameleonkvm):
     def destroy(self):
         # destroy the associated lease should be enough
         bclient = create_blazar_client(self.provider_conf)
-        lease = get_reservation(bclient)
+        lease = get_reservation(bclient, self.provider_conf)
         bclient.lease.delete(lease['id'])
         logger.info("Destroyed %s" % lease_to_s(lease))
 

--- a/enoslib/infra/enos_openstack/provider.py
+++ b/enoslib/infra/enos_openstack/provider.py
@@ -105,7 +105,8 @@ def check_glance(session, image_name):
     Fails if the base image isn't added.
     This means the image should be added manually.
     """
-    gclient = glance.Client(GLANCE_VERSION, session=session)
+    gclient = glance.Client(GLANCE_VERSION, session=session,
+                            region_name=os.environ['OS_REGION_NAME'])
     images = gclient.images.list()
     name_ids = [{'name': i['name'], 'id': i['id']} for i in images]
     if image_name not in map(itemgetter('name'), name_ids):
@@ -123,7 +124,8 @@ def check_flavors(session, resources):
 
     returns the mappings id <-> flavor
     """
-    nclient = nova.Client(NOVA_VERSION, session=session)
+    nclient = nova.Client(NOVA_VERSION, session=session,
+                          region_name=os.environ['OS_REGION_NAME'])
     flavors = nclient.flavors.list()
     to_id = dict(map(lambda n: [n.name, n.id], flavors))
     to_flavor = dict(map(lambda n: [n.id, n.name], flavors))
@@ -138,7 +140,8 @@ def check_network(session, configure_network, network, subnet,
         * private network /subnet
         * router between this network and the external network
     """
-    nclient = neutron.Client('2', session=session)
+    nclient = neutron.Client('2', session=session,
+                             region_name=os.environ['OS_REGION_NAME'])
 
     # Check the security groups
     secgroups = nclient.list_security_groups()['security_groups']
@@ -231,7 +234,8 @@ def check_network(session, configure_network, network, subnet,
 
 
 def get_free_floating_ip(env):
-    nclient = neutron.Client('2', session=env['session'])
+    nclient = neutron.Client('2', session=env['session'],
+                             region_name=os.environ['OS_REGION_NAME'])
     fips = nclient.list_floatingips()['floatingips']
     fips = [fip for fip in fips if fip['fixed_ip_address'] is None]
     if len(fips) > 0:
@@ -250,7 +254,8 @@ def wait_for_servers(session, servers):
 
     Note(msimonin): we don't garantee the SSH connection to be ready.
     """
-    nclient = nova.Client(NOVA_VERSION, session=session)
+    nclient = nova.Client(NOVA_VERSION, session=session,
+                          region_name=os.environ['OS_REGION_NAME'])
     while True:
         deployed = []
         undeployed = []
@@ -283,7 +288,8 @@ def check_servers(session, resources, extra_prefix="",
     This server can be used as a gateway to the others.
     """
     scheduler_hints = scheduler_hints or {}
-    nclient = nova.Client(NOVA_VERSION, session=session)
+    nclient = nova.Client(NOVA_VERSION, session=session,
+                          region_name=os.environ['OS_REGION_NAME'])
     servers = nclient.servers.list(
         search_opts={'name': '-'.join([PREFIX, extra_prefix])})
     wanted = _get_total_wanted_machines(resources)
@@ -329,7 +335,8 @@ def check_servers(session, resources, extra_prefix="",
 def check_gateway(env, with_gateway, servers):
     gateway = sorted(servers, key=lambda s: s.id)[0]
     if with_gateway:
-        nclient = nova.Client(NOVA_VERSION, session=env['session'])
+        nclient = nova.Client(NOVA_VERSION, session=env['session'],
+                              region_name=os.environ['OS_REGION_NAME'])
         gateway = nclient.servers.get(gateway.id)
         gw_floating_ips = [
             n for n in gateway.addresses[env['network']['name']]
@@ -357,7 +364,8 @@ def allow_address_pairs(session, network, subnet):
 
     This is particularly useful when working with virtual ips.
     """
-    nclient = neutron.Client('2', session=session)
+    nclient = neutron.Client('2', session=session,
+                             region_name=os.environ['OS_REGION_NAME'])
     ports = nclient.list_ports()
     ports_to_update = filter(
         lambda p: p['network_id'] == network['id'],
@@ -524,7 +532,8 @@ class Openstack(Provider):
 
     def destroy(self):
         session = get_session()
-        nclient = nova.Client(NOVA_VERSION, session=session)
+        nclient = nova.Client(NOVA_VERSION, session=session,
+                              region_name=os.environ['OS_REGION_NAME'])
         servers = nclient.servers.list()
         for server in servers:
             if is_in_current_deployment(server):

--- a/enoslib/infra/enos_openstack/provider.py
+++ b/enoslib/infra/enos_openstack/provider.py
@@ -486,6 +486,7 @@ class Openstack(Provider):
         servers = check_servers(
             env['session'],
             self.provider_conf['resources'],
+            self.provider_conf['prefix'],
             force_deploy=force_deploy,
             key_name=self.provider_conf.get('key_name'),
             image_id=env['image_id'],
@@ -524,6 +525,7 @@ class Openstack(Provider):
             'subnet': {'name': SUBNET_NAME, 'cidr': SUBNET_CIDR},
             'dns_nameservers': DNS_NAMESERVERS,
             'allocation_pool': ALLOCATION_POOL,
+            'prefix': PREFIX,
             'gateway': True,
             }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ chameleon =
     python-openstackclient>=3.0.0,<=4.0.0
     python-novaclient<10
     python-neutronclient==6.3.0
-    python-blazarclient==1.0.1
+    python-blazarclient==1.1.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This allows the current providers to respect the `OS_REGION_NAME` envvar for selecting what region to use.