### PR TITLE
Introduce drivers to interact with G5K

### DIFF
--- a/enoslib/infra/enos_g5k/constants.py
+++ b/enoslib/infra/enos_g5k/constants.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+ENV_NAME = "debian9-x64-nfs"
+JOB_NAME = "EnOSlib"
+WALLTIME = "02:00:00"
+JOB_TYPE_DEPLOY = "deploy"

--- a/enoslib/infra/enos_g5k/driver.py
+++ b/enoslib/infra/enos_g5k/driver.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from abc import ABCMeta, abstractmethod
+from enoslib.infra.enos_g5k.utils import (grid_get_or_create_job,
+                                          grid_reload_from_id,
+                                          grid_destroy_from_name,
+                                          grid_destroy_from_id)
+from enoslib.infra.enos_g5k.constants import (JOB_NAME, WALLTIME,
+                                              JOB_TYPE_DEPLOY)
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_driver(configuration):
+    """Build an instance of the driver to interact with G5K
+    """
+    resources = configuration["resources"]
+    machines = resources["machines"]
+    networks = resources["networks"]
+    oargrid_jobid = configuration.get("oargrid_jobid")
+    if oargrid_jobid:
+        logger.debug("Loading the OargridStaticDriver")
+        return OargridStaticDriver(oargrid_jobid)
+    else:
+        job_name = configuration.get("job_name", JOB_NAME)
+        walltime = configuration.get("walltime", WALLTIME)
+        job_type = configuration.get("job_type", JOB_TYPE_DEPLOY)
+        reservation_date = configuration.get("reservation", False)
+        # NOTE(msimonin): some time ago asimonet proposes to auto-detect
+        # the queues and it was quiet convenient
+        # see https://github.com/BeyondTheClouds/enos/pull/62
+        queue = configuration.get("queue", None)
+        logger.debug("Loading the OargridDynamicDriver")
+        return OargridDynamicDriver(
+            job_name,
+            walltime,
+            job_type,
+            reservation_date,
+            queue,
+            machines,
+            networks
+        )
+
+
+class Driver:
+    """Base class for all g5k drivers.
+
+    A driver is reponsible for interacting with Grid5000 to get resources and
+    destroy them. These action can be done using oar (single site), oargrid
+    (multisite) or the REST API.
+
+    TODO: Turn this into a singleton
+    """
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def reserve(self):
+        pass
+
+    @abstractmethod
+    def destroy(self):
+        pass
+
+
+class OargridStaticDriver(Driver):
+    """
+    Use this driver when a oargrid job id is given.
+
+    - reserve will reload the job resources from the job id
+    - destroy will destroy the oargrid job given its id
+    """
+    def __init__(self, oargrid_jobid):
+        self.oargrid_jobid = int(oargrid_jobid)
+
+    def reserve(self):
+        nodes, vlans, subnets = grid_reload_from_id(self.oargrid_jobid)
+        return nodes, vlans, subnets
+
+    def destroy(self):
+        grid_destroy_from_id(self.oargrid_jobid)
+
+
+class OargridDynamicDriver(Driver):
+    """
+    Use this driver when a new oargrid job must be created
+
+    - reserve will create or reload the job resources from the job name
+    - destroy will destroy the oargrid job given its name
+    """
+    def __init__(self, job_name,
+                 walltime,
+                 job_type,
+                 reservation_date,
+                 queue,
+                 machines,
+                 networks):
+        self.job_name = job_name
+        self.walltime = walltime
+        self.job_type = job_type
+        self.reservation_date = reservation_date
+        self.queue = queue
+        self.machines = machines
+        self.networks = networks
+
+    def reserve(self):
+        gridjob = grid_get_or_create_job(self.job_name,
+                                         self.walltime,
+                                         self.reservation_date,
+                                         self.queue,
+                                         self.job_type,
+                                         self.machines,
+                                         self.networks)
+
+        nodes, vlans, subnets = grid_reload_from_id(gridjob)
+        return nodes, vlans, subnets
+
+    def destroy(self):
+        grid_destroy_from_name(self.job_name)

--- a/enoslib/infra/enos_g5k/schema.py
+++ b/enoslib/infra/enos_g5k/schema.py
@@ -23,7 +23,6 @@ SCHEMA = {
     },
     "additionalProperties": True,
     "required": ["resources"],
-
     "resources": {
         "title": "Resource",
 

--- a/enoslib/tests/unit/infra/enos_g5k/test_api.py
+++ b/enoslib/tests/unit/infra/enos_g5k/test_api.py
@@ -11,7 +11,7 @@ class TestGetNetwork(EnosTest):
     def test_no_concrete_network_yet(self):
         expected_networks = [{"type": PROD, "id": "network1"}]
         schema.validate = mock.Mock()
-        r = Resources({"networks": expected_networks})
+        r = Resources({"resources": {"networks": expected_networks, "machines": []}})
         networks = r.get_networks()
         self.assertCountEqual(expected_networks, networks)
 
@@ -19,7 +19,7 @@ class TestGetNetwork(EnosTest):
         networks = [{"type": KAVLAN, "id": "network1", "_c_network": {"site": "nancy", "vlan_id": 1}}]
         expected_networks = [{"type": KAVLAN, "id": "network1", "site": "nancy", "vlan_id": 1}]
         schema.validate = mock.Mock()
-        r = Resources({"networks": networks})
+        r = Resources({"resources": {"networks": networks, "machines": []}})
         networks = r.get_networks()
         self.assertCountEqual(expected_networks, networks)
 
@@ -30,11 +30,13 @@ class TestDeploy(EnosTest):
         nodes = ["foocluster-1", "foocluster-2"]
         schema.validate = mock.Mock()
         r = Resources({
-            "machines": [{
-                "_c_nodes": nodes,
-                "primary_network": "network1"
-            }],
-            "networks": [{"type": PROD, "id": "network1"}]
+            "resources":{
+                "machines": [{
+                    "_c_nodes": nodes,
+                    "primary_network": "network1"
+                }],
+                "networks": [{"type": PROD, "id": "network1"}]
+            }
         })
         deployed = set(["foocluster-1", "foocluster-2"])
         undeployed = set()
@@ -48,11 +50,13 @@ class TestDeploy(EnosTest):
         nodes = ["foocluster-1", "foocluster-2"]
         schema.validate = mock.Mock()
         r = Resources({
-            "machines": [{
-                "_c_nodes": nodes,
-                "primary_network": "network1"
-            }],
-            "networks": [{"type": KAVLAN, "id": "network1", "_c_network": {"site": "rennes", "vlan_id": 4}}]
+            "resources": {
+                "machines": [{
+                    "_c_nodes": nodes,
+                    "primary_network": "network1"
+                }],
+                "networks": [{"type": KAVLAN, "id": "network1", "_c_network": {"site": "rennes", "vlan_id": 4}}]
+            }
         })
         deployed = set(["foocluster-1", "foocluster-2"])
         undeployed = set()
@@ -67,17 +71,19 @@ class TestDeploy(EnosTest):
         nodes_bar = ["barcluster-1", "barcluster-2"]
         schema.validate = mock.Mock()
         r = Resources({
-            "machines": [{
-                "_c_nodes": nodes_foo,
-                "primary_network": "network1"
-            },{
-                "_c_nodes" : nodes_bar,
-                "primary_network": "network2"
-                }
-            ],
-            "networks": [
-                {"type": PROD, "id": "network1"},
-                {"type": KAVLAN, "id": "network2", "_c_network": {"site": "rennes", "vlan_id": 4}}]
+            "resources": {
+                "machines": [{
+                    "_c_nodes": nodes_foo,
+                    "primary_network": "network1"
+                },{
+                    "_c_nodes" : nodes_bar,
+                    "primary_network": "network2"
+                    }
+                ],
+                "networks": [
+                    {"type": PROD, "id": "network1"},
+                    {"type": KAVLAN, "id": "network2", "_c_network": {"site": "rennes", "vlan_id": 4}}]
+            }
         })
         d_foo = set(["foocluster-1"])
         u_foo = set(nodes_foo) - d_foo

--- a/enoslib/tests/unit/infra/enos_g5k/test_driver.py
+++ b/enoslib/tests/unit/infra/enos_g5k/test_driver.py
@@ -1,0 +1,26 @@
+import unittest
+from enoslib.infra.enos_g5k.driver import *
+
+class TestGetDriver(unittest.TestCase):
+
+    def test_getdriver_oargriddynamic(self):
+        resources = {
+            "resources": {
+                "machines": [],
+                "networks": [],
+            }
+        }
+        driver = get_driver(resources)
+        self.assertIsInstance(driver, OargridDynamicDriver)
+
+    def test_getdriver_oargridstatic(self):
+        resources = {
+            "oargrid_jobid": "1234",
+            "resources": {
+                "machines": [],
+                "networks": [],
+            }
+        }
+        driver = get_driver(resources)
+        self.assertIsInstance(driver, OargridStaticDriver)
+


### PR DESCRIPTION
    Introduce drivers to interact with G5K
    
    A Driver is reponsible for reserving, reloading or destroying the
    resources. It can interact for example with OAR, OARGRID or the REST
    API. Currently two drivers that interact with OARGRID are implemented:
    
    - a dynamic (OargridDynamicDriver) that reserves resources according the
    the provider configuration
    
    - a static (OargridStaticDriver) that only reloads the resources given
    an oargrid jobid. The reservation must be handled externally.
    
    Drivers are implemented in the driver.py file.
    The function ``get_driver` reads the provider configuration and load the
    relevant driver.
