### PR TITLE
Relax a bit the schema of Chameleon

### DIFF
--- a/enoslib/infra/enos_chameleonkvm/schema.py
+++ b/enoslib/infra/enos_chameleonkvm/schema.py
@@ -15,7 +15,7 @@ SCHEMA = {
         "subnet": {"$ref": "#/os_subnet"},
         "prefix": {"type": "string"}
     },
-    "additionalProperties": False,
+    "additionalProperties": True,
     "required": ["resources", "key_name"],
 
     "os_allocation_pool": {
@@ -46,7 +46,7 @@ SCHEMA = {
             "name": {"type": "string"},
             "cidr": {"type": "string"}
         },
-        "required": ["name", "cidr"],
+        "required": ["name"],
         "additionalProperties": False
     },
 


### PR DESCRIPTION
It's shared between chameleonkvm (ckvm) and chameleonbaremetal (cbm). cbm needs
some more keys in comparison to ckvm. Logically speaking cbm inheritate from
ckvm and instead of duplicating the whole schema, we choose to relax a bit so
that this inheritance can occur also at the schema level. (It seems that there
isn't an obvious mechanism to map the inheritance from the objet layer to the
schema level).